### PR TITLE
Add wc-reset function to 'reset' counts.

### DIFF
--- a/wc-mode.el
+++ b/wc-mode.el
@@ -178,6 +178,15 @@ Also cheat here a bit and add nil-value processing."
 	      (abs val))
     "none"))
 
+(defun wc-reset ()
+  "Reset the original word, line, and char count to their current
+value."
+  (interactive)
+  (setq wc-orig-words nil)
+  (setq wc-orig-lines nil)
+  (setq wc-orig-chars nil)
+  (wc-mode-update))
+
 (defun wc-set-word-goal (goal)
   "Set a goal for adding or removing words in the buffer"
   (interactive "nHow many words: ")


### PR DESCRIPTION
It might be useful to have a function that can be used to 'reset' the counts so that you can, e.g., set a 750 word/day goal without constantly closing/opening the buffer.

I wasn't sure whether you'd want it in the mode map so I left it out, but I'm fine with whatever key combination you decide fits.
