### PR TITLE
Allow wc stat generation to be deferred to idle periods (plus some formalities)

### DIFF
--- a/wc-mode.el
+++ b/wc-mode.el
@@ -1,5 +1,4 @@
-;;; wc-mode.el --- Running word count with goals (minor mode)
-;;
+;;; wc-mode.el --- Running word count with goals (minor mode) -*- lexical-binding: t -*-
 ;; Author: Benjamin Beckwith
 ;; Created: 2010-6-19
 ;; Version: 1.3
@@ -92,6 +91,19 @@ It will looks something like WC[742+360/1100] in the modeline.
   :type 'hook
   :group 'wc)
 
+(defcustom wc-idle-wait 0
+  "This variable configures how many idle seconds wc-mode will
+wait before initiating wc-count.  0 and negative numbers provide
+a continuously updating word-count in the modeline.  Set this to
+a positive integer or float to defend against the lag and
+potential distraction of a continuously updating modeline.  A
+high value may enhance battery life, because large buffers will
+not be processed until one takes a break from work.
+
+Defaults to 0 for backwards compatibility."
+  :type 'number
+  :group 'wc)
+
 (defface wc-goal-face
   '((t (:inherit highlight)))
   "Face for modeline when goal is reached"
@@ -164,6 +176,18 @@ RSTART and REND."
 Format will be evaluated in `wc-generate-modeline'")
 
 (defvar wc-mode-hooks nil "Hooks to run upon entry to wc-mode")
+
+(defvar-local wc-timer-tracker nil
+  "Buffer-local timers for wc-count.  Each buffer where wc-mode
+is enabled has a timer, and this allows them to be found and
+cleaned up when their respective buffers are closed.
+
+TODO: word-count stats should not be generated for
+inactive/hidden buffers.")
+
+(defvar-local wc-buffer-stats nil
+  "This variable holds the per-buffer word-count statistics used to
+update the modeline.")
 
 (defun wc-format-modeline-string (fmt)
   "Format the modeline string according to specification and return result"
@@ -287,6 +311,17 @@ operate over the entire buffer.
     (setq wc-chars-delta (- (nth 2 stats) wc-orig-chars))
     (wc-generate-modeline)))
 
+(setq wc-timer-tracker
+      (run-with-idle-timer
+       wc-idle-wait t
+       '(lambda ()
+          (setq wc-buffer-stats (wc-mode-update)))))
+
+(add-hook 'kill-buffer-hook
+          (lambda ()
+            (when (timerp wc-timer-tracker)
+              (cancel-timer wc-timer-tracker))))
+
 ;;;###autoload
 (define-minor-mode wc-mode
   "Toggle wc mode With no argument, this command toggles the
@@ -309,7 +344,7 @@ value is non-nil."
   ;; initial value (off)
   :init-value nil
   ;; The indicator for the mode line
-  :lighter (:eval (wc-mode-update))
+  :lighter (:eval wc-buffer-stats)
   ;; The customization group
   :group 'wc
   ;; The local keymap to use

--- a/wc-mode.el
+++ b/wc-mode.el
@@ -1,11 +1,17 @@
 ;;; wc-mode.el --- Running word count with goals (minor mode) -*- lexical-binding: t -*-
+
+;; Copyright: 2010-2017  Benjamin Beckwith
+;;            2019  Nicholas D Steeves (willing to assign to FSF for GNU Emacs)
+
 ;; Author: Benjamin Beckwith
 ;; Created: 2010-6-19
 ;; Version: 1.3
-;; Last-Updated: 2016-10-31
+;; Last-Updated: 2019-06-28
 ;; URL: https://github.com/bnbeckwith/wc-mode
+;; Package-Requires: ((emacs "24.1"))
 ;; Keywords:
 ;; Compatability:
+;; License: GPL-3.0-or-later
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/wc-mode.el
+++ b/wc-mode.el
@@ -10,7 +10,7 @@
 ;; URL: https://github.com/bnbeckwith/wc-mode
 ;; Package-Requires: ((emacs "24.1"))
 ;; Keywords:
-;; Compatability:
+;; Compatibility:
 ;; License: GPL-3.0-or-later
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -140,7 +140,7 @@ Defaults to 0 for backwards compatibility."
 
 (defvar wc-word-goal nil "Goal for number of words added")
 (defvar wc-line-goal nil "Goal for number of lines added")
-(defvar wc-char-goal nil "Goal for numger of chars added")
+(defvar wc-char-goal nil "Goal for number of chars added")
 (make-variable-buffer-local 'wc-word-goal)
 (make-variable-buffer-local 'wc-line-goal)
 (make-variable-buffer-local 'wc-char-goal)
@@ -362,4 +362,3 @@ value is non-nil."
 (provide 'wc-mode)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; wc-mode.el ends here
-

--- a/wc-mode.el
+++ b/wc-mode.el
@@ -27,6 +27,10 @@
 ;;
 ;;; Change Log:
 ;;
+;; 1.4 Switch to lexical binding.
+;;     Add configurable timer, which, if set to a positive value
+;;     defers CPU intensive stat counting to idle periods.
+;;     Wc-mode now requires Emacs >= 24.1
 ;; 1.3 Goal functions now perform reset by default
 ;; 1.2 Reset functions added
 ;; 1.1 Counting functions tied to buffer-local variables


### PR DESCRIPTION
Hi @bnbeckwith,

I've documented everything fairly well in the commits and docstrings, so there's not much to write here.  Oh, I took the liberty to add you as a formal copyright holder, because I needed to add myself, because the FSF considers something like ≥25 lines of contributions significant.  I also checked the git stats, and no other contributors meet that criteria.

So as things stand, if in the future you wanted to submit wc-mode for inclusion into upstream GNU Emacs everything is documented and it's just a matter of filling out a bit of paperwork--plus contacting me to ask me to do the same.

Thanks again for maintaining this package!